### PR TITLE
Pass options to transformers

### DIFF
--- a/index.js
+++ b/index.js
@@ -226,6 +226,7 @@ Deps.prototype.getTransforms = function (file, pkg, opts) {
             trOpts = tr[1];
             tr = tr[0];
         }
+        trOpts._flags = '_flags' in opts ? opts._flags : self.options;
         if (typeof tr === 'function') {
             var t = tr(file, trOpts);
             self.emit('transform', t, file);


### PR DESCRIPTION
This PR exposes the options sent to `module-deps` to the transformers. It does so by assigning the `module-deps` options to a `_flags` property on the transformer options, just like `browserify` does.

The motivation for this PR is to make the bahaviour of transformers configured via `package.json` similar to that of transformers configured via CLI or scripts: in the `browserify` toolchain the later two methods of specifying a transformer (CLI and scripts)  will attach the `_flags` property to the transformer options ([here](https://github.com/substack/node-browserify/blob/adacea35f76d0a8645cc001752472c98fcdb6c60/index.js#L261)), but transformers specified in the `package.json` do not. 
