### PR TITLE
Improve error messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -356,7 +356,12 @@ Deps.prototype.walk = function (id, parent, cb) {
             self.emit('missing', id, parent);
             return cb && cb(null, undefined);
         }
-        if (err) return self.emit('error', err);
+        if (err) {
+            var message = 'Can\'t walk dependency graph: ' + err.message;
+            message += '\n    required by ' + parent.filename;
+            err = new Error(message);
+            return self.emit('error', err);
+        }
         if (self.visited[file]) {
             if (-- self.pending === 0) self.push(null);
             if (input) --self.inputPending;

--- a/index.js
+++ b/index.js
@@ -359,7 +359,7 @@ Deps.prototype.walk = function (id, parent, cb) {
         if (err) {
             var message = 'Can\'t walk dependency graph: ' + err.message;
             message += '\n    required by ' + parent.filename;
-            err = new Error(message);
+            err.message = message;
             return self.emit('error', err);
         }
         if (self.visited[file]) {


### PR DESCRIPTION
A typical error message (e.g. Browserify) with this module looks like the following:
```
Error: Cannot find module './nonexistant' from '/code/project/test'
    at /code/project/node_modules/resolve/lib/async.js:46:17
    at process (/code/project/node_modules/resolve/lib/async.js:173:43)
    at ondir (/code/project/node_modules/resolve/lib/async.js:188:17)
    at load (/code/project/node_modules/resolve/lib/async.js:69:43)
    at onex (/code/project/node_modules/resolve/lib/async.js:92:31)
    at /code/project/node_modules/resolve/lib/async.js:22:47
    at FSReqWrap.oncomplete (fs.js:123:15)
```

This has several issues. First, it does not show the file from which the missing module is being required (it does show the name of the missing file/module and the directory from which it is searching). Second, the stack trace doesn't provide a good indication of the source of the modules involved. Users with monolithic build tasks will find this error extremely confusing, as it does not provide a clear indication of what action could have generated this error, why it was generated, where it was generated or how to fix it. 

This PR changes the error such that it appears like so: 
```
Error: Can't walk dependency graph: Cannot find module './nonexistant' from '/code/project/test'
    required by /code/project/test/deep4.js
    at /code/project/node_modules/module-deps/index.js:362:19
    at onresolve (/code/project/node_modules/module-deps/index.js:174:25)
    at /code/project/node_modules/browserify/index.js:490:22
    at /code/project/node_modules/browser-resolve/index.js:265:24
    at /code/project/node_modules/resolve/lib/async.js:55:18
    at load (/code/project/node_modules/resolve/lib/async.js:69:43)
    at onex (/code/project/node_modules/resolve/lib/async.js:92:31)
    at /code/project/node_modules/resolve/lib/async.js:22:47
    at FSReqWrap.oncomplete (fs.js:123:15)
```

This error:
  * shows the requiring file
  * has a stack trace that presents a better indication of the origin of the error (Browserify is listed directly, along with several other involved modules)

Ideally, this error would give the entire traceback (in the form of `required by `) from the unresolved module `./nonexistant` all the way back up the require chain to the entry file, but that is a non-trivial change.

60/60 tests passing.