### PR TITLE
Fix: File events with persistent cache

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var fs = require('fs');
 var path = require('path');
-var relativePath = require('cached-path-relative')
+var relativePath = require('cached-path-relative');
 
 var browserResolve = require('browser-resolve');
 var nodeResolve = require('resolve');
@@ -280,7 +280,7 @@ Deps.prototype.getTransforms = function (file, pkg, opts) {
             if (err) {
                 params.basedir = pkg.__dirname;
                 return nodeResolve(id, params, function (e, r) {
-                    nr(e, r, true)
+                    nr(e, r, true);
                 });
             }
             
@@ -529,7 +529,7 @@ Deps.prototype.lookupPackage = function (file, cb) {
             catch (err) {
                 return onpkg(new Error([
                     err + ' while parsing json file ' + pkgfile
-                ].join('')))
+                ].join('')));
             }
             pkg.__dirname = dir;
             
@@ -544,8 +544,8 @@ Deps.prototype.lookupPackage = function (file, cb) {
                 delete self.pkgFileCachePending[pkgfile];
                 fns.forEach(function (f) { f(err, pkg) });
             }
-            if (err) cb(err)
-            else if (pkg) cb(null, pkg)
+            if (err) cb(err);
+            else if (pkg) cb(null, pkg);
             else {
                 self.pkgCache[pkgfile] = false;
                 next();

--- a/test/cache_persistent.js
+++ b/test/cache_persistent.js
@@ -78,4 +78,45 @@ test('allow passing of the raw source as string', function (t) {
     });
 });
 
+test('send file event with persistent cache', function (t) {
+    t.plan(2);
+    var p = parser({
+        persistentCache: function (file, id, pkg, fallback, cb) {
+            cb(null, {
+                source: 'file at ' + file + '@' + id,
+                package: pkg,
+                deps: {}
+            });
+        }
+    });
+    p.end({ id: 'foo', file: files.foo, entry: false });
+    p.on('file', function (file, id) {
+        t.same(file, path.resolve(files.foo));
+        t.same(id, path.resolve(files.foo));
+    });
+});
+
+test('errors of transforms occur in the correct order with a persistent cache', function (t) {
+    t.plan(3);
+    var p = parser({
+        transform: [
+            path.join(__dirname, 'cache_persistent', 'error_transform')
+        ],
+        persistentCache: function (file, id, pkg, fallback, cb) {
+            fallback(fs.readFileSync(files.foo, 'utf8'), cb);
+        }
+    });
+    p.end({ id: 'foo', file: files.foo, entry: false });
+    var order = 0;
+    p.on('file', function (file, id) {
+        t.same(order, 0);
+        order += 1;
+    });
+    p.on('error', function (err) {
+        t.same(order, 1);
+        t.same(err.message, 'rawr while parsing file: ' + path.resolve(files.foo));
+    });
+});
+
+
 function cmp (a, b) { return a.id < b.id ? -1 : 1 }

--- a/test/cache_persistent.js
+++ b/test/cache_persistent.js
@@ -13,13 +13,13 @@ test('uses persistent cache', function (t) {
     var p = parser({
         persistentCache: function (file, id, pkg, fallback, cb) {
             if (file === files.bar) {
-                return fallback(null, cb)
+                return fallback(null, cb);
             }
             cb(null, {
                 source: 'file at ' + file + '@' + id,
                 package: pkg,
                 deps: { './bar': files.bar }
-            })
+            });
         }
     });
     p.end({ id: 'foo', file: files.foo, entry: false });
@@ -48,7 +48,7 @@ test('passes persistent cache error through', function (t) {
     t.plan(1);
     var p = parser({
         persistentCache: function (file, id, pkg, fallback, cb) {
-            cb(new Error('foo'))
+            cb(new Error('foo'));
         }
     });
     p.end({ id: 'foo', file: files.foo, entry: false });
@@ -59,7 +59,7 @@ test('allow passing of the raw source as string', function (t) {
     t.plan(1);
     var p = parser({
         persistentCache: function (file, id, pkg, fallback, cb) {
-            fallback(fs.readFileSync(files.bar, 'utf8'), cb)
+            fallback(fs.readFileSync(files.bar, 'utf8'), cb);
         }
     });
     p.end({ id: 'foo', file: files.foo, entry: false });

--- a/test/cache_persistent/error_transform.js
+++ b/test/cache_persistent/error_transform.js
@@ -1,0 +1,6 @@
+var through = require('through2');
+module.exports = function (file) {
+    return through(function (chunk, enc, callback) {
+        callback(new Error('rawr'));
+    });
+};


### PR DESCRIPTION
Sadly I introduced a bug when adding the persistent cache to module-deps in v4.1.0. 😥

The persistent cache doesn't send a `file` event since that event would be triggered only in case the fallback was published.

This PR fixes the event behaviour by sending the file and error event after checking the file in the cache. 💡 

To maintain the order of the events, the errors now bubble through the `dup` ([L#237](https://github.com/substack/module-deps/commit/28d79ee6b96ea601e63bfb5a7af2934c6e4aee7e#diff-168726dbe96b3ce427e7fedce31bb0bcR237), [L#250](https://github.com/substack/module-deps/commit/28d79ee6b96ea601e63bfb5a7af2934c6e4aee7e#diff-168726dbe96b3ce427e7fedce31bb0bcR250)) rather than `self`. This way the errors can be passed to the callback []() and thus is guaranteed to run after [the file event L#388
](https://github.com/substack/module-deps/commit/28d79ee6b96ea601e63bfb5a7af2934c6e4aee7e#diff-168726dbe96b3ce427e7fedce31bb0bcR388)
Since the processing of the error is now different for the two process routes: the errors have to be bubbled on when `rec.source` is given on [L#350](https://github.com/substack/module-deps/commit/28d79ee6b96ea601e63bfb5a7af2934c6e4aee7e#diff-168726dbe96b3ce427e7fedce31bb0bcR350) and [L#375](https://github.com/substack/module-deps/commit/28d79ee6b96ea601e63bfb5a7af2934c6e4aee7e#diff-168726dbe96b3ce427e7fedce31bb0bcR375) but sent to the callback in the the `persistentCacheFallback` on  [L#397](https://github.com/substack/module-deps/commit/28d79ee6b96ea601e63bfb5a7af2934c6e4aee7e#diff-168726dbe96b3ce427e7fedce31bb0bcR397) and [L#403](https://github.com/substack/module-deps/commit/28d79ee6b96ea601e63bfb5a7af2934c6e4aee7e#diff-168726dbe96b3ce427e7fedce31bb0bcR403) instead of in [readFile L#209](https://github.com/substack/module-deps/commit/28d79ee6b96ea601e63bfb5a7af2934c6e4aee7e#diff-168726dbe96b3ce427e7fedce31bb0bcL209)

After all that, the order _should_ stay consistent but there are not enough tests for the correct order to feel 100% confident. _(and I am not sure how to test all cases properly)_

_However..._ I didn't find a good way to preserve the current event timing. The `file` events will now bubble later than they did before, after the processing of the file. In many cases they will even be executed in the same tick because the file emit is in the same scope as the error emit [L#388
](https://github.com/substack/module-deps/commit/28d79ee6b96ea601e63bfb5a7af2934c6e4aee7e#diff-168726dbe96b3ce427e7fedce31bb0bcR388) 😅 

_I thought about moving them at least 1 tick apart with process.nextTick but I wondered if that is just a bit too cautious._ 🤔

cc. @jesstelford