### PR TITLE
Don't preserve symlinks when resolving deps

### DIFF
--- a/index.js
+++ b/index.js
@@ -273,7 +273,10 @@ Deps.prototype.getTransforms = function (file, pkg, opts) {
     }
     
     function loadTransform (id, trOpts, cb) {
-        var params = { basedir: path.dirname(file) };
+        var params = {
+            basedir: path.dirname(file),
+            preserveSymlinks: false
+        };
         nodeResolve(id, params, function nr (err, res, again) {
             if (err && again) return cb && cb(err);
             

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "inherits": "^2.0.1",
     "parents": "^1.0.0",
     "readable-stream": "^2.0.2",
-    "resolve": "^1.1.3",
+    "resolve": "^1.4.0",
     "stream-combiner2": "^1.1.1",
     "subarg": "^1.0.0",
     "through2": "^2.0.0",


### PR DESCRIPTION
For context see: https://github.com/browserify/resolve/pull/131

This fixes browserify for projects that use pnpm.
Related issue at pnpm: https://github.com/pnpm/pnpm/issues/795