### PR TITLE
[WIP] ES modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -470,7 +470,14 @@ Deps.prototype.walk = function (id, parent, cb) {
             if (!rec.deps) rec.deps = resolved;
             if (!rec.file) rec.file = file;
             if (opts.esm && isEsm(file)) {
-                rec.esm = { imports: imports, exports: exports };
+                rec.esm = {
+                    imports: imports.map(function (imp) {
+                        var name = imp.from;
+                        if (isEsm(rec.deps[name])) { imp.esm = true; }
+                        return imp;
+                    }),
+                    exports: exports
+                };
             }
             
             if (self.entries.indexOf(file) >= 0) {

--- a/index.js
+++ b/index.js
@@ -261,6 +261,9 @@ Deps.prototype.getTransforms = function (file, pkg, opts) {
             tr = tr[0];
         }
         trOpts._flags = trOpts.hasOwnProperty('_flags') ? trOpts._flags : self.options;
+        if (isEsm(file)) {
+            trOpts._flags = Object.assign({}, trOpts._flags, { esm: true });
+        }
         if (typeof tr === 'function') {
             var t = tr(file, trOpts);
             self.emit('transform', t, file);

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "concat-stream": "~1.5.0",
     "defined": "^1.0.0",
     "detective": "^4.0.0",
+    "detective-esm": "*",
     "duplexer2": "^0.1.2",
     "inherits": "^2.0.1",
     "parents": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "concat-stream": "~1.5.0",
     "defined": "^1.0.0",
     "detective": "^4.0.0",
-    "detective-esm": "*",
+    "detective-esm": "browserify/detective-esm",
     "duplexer2": "^0.1.2",
     "inherits": "^2.0.1",
     "parents": "^1.0.0",


### PR DESCRIPTION
Adds node-style experimental ES modules support. pass `esm: true` to interpret `.mjs` files as ES modules.

ES modules get a `rec.esm` property so that later parts in the browserify pipeline can identify them. `rec.esm` is an object containing properties:

 - `rec.esm.imports` - array of imported bindings
 - `rec.esm.exports` - array of exported bindings

Imported bindings are objects of the form:

 - `binding.from` - source module (value `"a"` in `import "a"`)
 - `binding.import` - imported binding
 - `binding.as` - local name for the binding (often the same as `binding.import`)
 - `binding.esm` - true if the source module is also an ES module, false if it is a commonjs module.

Exported bindings are objects of the form:

 - `binding.export` - local name of the binding (can be undefined if `export default`-ing an unnamed expression)
 - `binding.as` - public name of the binding

Transforms can check `opts._flags.esm` to see if the module being transformed is an ES module (true) or a CommonJS module (false). It might be useful if transforms could also _set_ `opts._flags.esm` to mark their _output_ as an ES module, for languages that compile to ES modules.