### PR TITLE
Bump detective

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
-  - "0.8"
-  - "0.10"
-  - "0.12"
-  - "iojs"
-before_install:
-  - npm install -g npm@~1.4.6
+  - 9
+  - 8
+  - 6
+  - 4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# module-deps Change Log
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## 5.0.0 - 2018-01-02
+* Update deps
+* Drop support for node < 0.12 due due to detective dropping support
+* Add engines field set to `>=4.0.0`

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
     "JSONStream": "^1.0.3",
     "browser-resolve": "^1.7.0",
     "cached-path-relative": "^1.0.0",
-    "concat-stream": "~1.5.0",
+    "concat-stream": "~1.6.0",
     "defined": "^1.0.0",
-    "detective": "^4.7.1",
+    "detective": "^5.0.1",
     "duplexer2": "^0.1.2",
     "inherits": "^2.0.1",
     "parents": "^1.0.0",
@@ -24,8 +24,8 @@
     "xtend": "^4.0.0"
   },
   "devDependencies": {
-    "tap": "^1.0.0",
-    "browser-pack": "^5.0.0"
+    "tap": "^11.0.1",
+    "browser-pack": "^6.0.2"
   },
   "scripts": {
     "test": "tap test/*.js"


### PR DESCRIPTION
This bumps detective to `^5.0.1` in order to not crash on files with the spread operator.  I also took the opportunity to bump deps, drop 0.12 support, update CI env and add a changelog.