### PR TITLE
Update engines field to 4.0 or higher

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "url": "http://substack.net"
   },
   "engines": {
-    "node": ">= 0.6"
+    "node": ">= 4.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Testing against older versions was dropped in a436f523deccbde5e6136c1f9cd646f65abdf487