### PR TITLE
Update detective and roll back to 0.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,15 @@
 language: node_js
 node_js:
-  - 9
-  - 8
-  - 6
-  - 4
+  - "9"
+  - "8"
+  - "6"
+  - "4"
+  - "iojs"
+  - "0.12"
+  - "0.10"
+  - "0.8"
+sudo: false
+before_install:
+  - 'nvm install-latest-npm'
+matrix:
+  fast_finish: true

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "cached-path-relative": "^1.0.0",
     "concat-stream": "~1.6.0",
     "defined": "^1.0.0",
-    "detective": "^5.0.1",
+    "detective": "^5.0.2",
     "duplexer2": "^0.1.2",
     "inherits": "^2.0.1",
     "parents": "^1.0.0",
@@ -50,7 +50,7 @@
     "url": "http://substack.net"
   },
   "engines": {
-    "node": ">= 4.0"
+    "node": ">= 0.8.0"
   },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "xtend": "^4.0.0"
   },
   "devDependencies": {
-    "tap": "^11.0.1",
+    "tap": "^1.0.0",
     "browser-pack": "^6.0.2"
   },
   "scripts": {


### PR DESCRIPTION
Roll back to support to 0.8. 

Related: https://github.com/browserify/browserify/pull/1794