### PR TITLE
add 'dep' event to transforms

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -203,6 +203,10 @@ You don't necessarily need to use the
 readable/writable filter stream for transforming file contents, but this is an
 easy way to do it.
 
+module-deps looks for `require()` calls and adds their arguments as dependencies
+of a file. Transform streams can emit `'dep'` events to include additional
+dependencies that are not consumed with `require()`.
+
 When you call `mdeps()` with an `opts.transform`, the transformations you
 specify will not be run for any files in node_modules/. This is because modules
 you include should be self-contained and not need to worry about guarding

--- a/test/files/transformdeps.js
+++ b/test/files/transformdeps.js
@@ -1,0 +1,1 @@
+// dependencies added by transform

--- a/test/tr_deps.js
+++ b/test/tr_deps.js
@@ -1,0 +1,60 @@
+var parser = require('../');
+var through = require('through2');
+var test = require('tap').test;
+var fs = require('fs');
+var path = require('path');
+
+var files = {
+    transformdeps: path.join(__dirname, '/files/transformdeps.js'),
+    foo: path.join(__dirname, '/files/foo.js'),
+    bar: path.join(__dirname, '/files/bar.js')
+};
+
+var sources = Object.keys(files).reduce(function (acc, file) {
+    acc[file] = fs.readFileSync(files[file], 'utf8');
+    return acc;
+}, {});
+
+test('deps added by transforms', function (t) {
+    t.plan(1);
+    var p = parser();
+    p.write({ transform: transform, options: {} });
+    p.end({ file: files.transformdeps, entry: true });
+    function transform (file) {
+        if (file === files.transformdeps) return through(function(chunk, enc, cb) {
+            cb(null, chunk);
+        }, function (cb) {
+            this.emit('dep', './foo');
+            cb();
+        });
+        return through();
+    }
+    
+    var rows = [];
+    p.on('data', function (row) { rows.push(row) });
+    p.on('end', function () {
+        t.same(rows.sort(cmp), [
+            {
+                id: files.transformdeps,
+                file: files.transformdeps,
+                source: sources.transformdeps,
+                entry: true,
+                deps: { './foo': files.foo }
+            },
+            {
+                id: files.foo,
+                file: files.foo,
+                source: sources.foo,
+                deps: { './bar': files.bar }
+            },
+            {
+                id: files.bar,
+                file: files.bar,
+                source: sources.bar,
+                deps: {}
+            }
+        ].sort(cmp));
+    });
+});
+
+function cmp (a, b) { return a.id < b.id ? -1 : 1 }


### PR DESCRIPTION
When a transform stream emits 'dep', the path is added to the
transformed file's dependencies.
This is useful for something like [split-require][0] which uses a custom
`require`-like function. Instead of transforming the source code and
adding in dummy `require()` calls, split-require could emit the 'dep'
event.

[0]: https://github.com/goto-bus-stop/split-require