### PR TITLE
Add .npmignore to make the published module smaller and work around a bug in Flow

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+.travis.yml
+example
+test


### PR DESCRIPTION
This will make everyone's life slightly better by making the module distributed through npm a bit smaller.

And it will save users of Flow some grief, because of facebook/flow#5898.