### PR TITLE
 Fix crash when file has a transform and a syntax error, fixes #144

### DIFF
--- a/index.js
+++ b/index.js
@@ -263,9 +263,9 @@ Deps.prototype.getTransforms = function (file, pkg, opts) {
         if (typeof tr === 'function') {
             var t = tr(file, trOpts);
             // allow transforms to `stream.emit('dep', path)` to add dependencies for this file
-            self._transformDeps[file] = [];
             t.on('dep', function (dep) {
-              self._transformDeps[file].push(dep);
+                if (!self._transformDeps[file]) self._transformDeps[file] = [];
+                self._transformDeps[file].push(dep);
             });
             self.emit('transform', t, file);
             nextTick(cb, null, wrapTransform(t));
@@ -309,9 +309,9 @@ Deps.prototype.getTransforms = function (file, pkg, opts) {
             
             var trs = r(file, trOpts);
             // allow transforms to `stream.emit('dep', path)` to add dependencies for this file
-            self._transformDeps[file] = [];
             trs.on('dep', function (dep) {
-              self._transformDeps[file].push(dep);
+                if (!self._transformDeps[file]) self._transformDeps[file] = [];
+                self._transformDeps[file].push(dep);
             });
             self.emit('transform', trs, file);
             cb(null, trs);
@@ -434,6 +434,7 @@ Deps.prototype.walk = function (id, parent, cb) {
 
     function getDeps (file, src) {
         var deps = rec.noparse ? [] : self.parseDeps(file, src);
+        if (!deps) return;
         // dependencies emitted by transforms
         if (self._transformDeps[file]) deps = deps.concat(self._transformDeps[file]);
         return deps;

--- a/test/files/syntax_error.js
+++ b/test/files/syntax_error.js
@@ -1,0 +1,2 @@
+const a = require('a');
+const a = 0;

--- a/test/syntax.js
+++ b/test/syntax.js
@@ -1,0 +1,19 @@
+var mdeps = require('../');
+var test = require('tap').test;
+var JSONStream = require('JSONStream');
+var packer = require('browser-pack');
+var through = require('through2');
+var path = require('path');
+
+test('syntax error', function (t) {
+    t.plan(1);
+    // ensure transformDeps functionality does not break when parse errors happen
+    // see https://github.com/browserify/module-deps/commit/9fe46d5#commitcomment-28273437
+    var p = mdeps({
+        transform: function () { return through(); }
+    });
+    p.on('error', function (err) {
+        t.ok(err);
+    });
+    p.end(path.join(__dirname, '/files/syntax_error.js'));
+});


### PR DESCRIPTION
Ref https://github.com/browserify/module-deps/commit/9fe46d5566e20f7a1fe801d2ef4cbb5fe9b7aa7d#commitcomment-28273437

`parseDeps` returns undefined on a syntax error, so `deps.concat`ing it
does not work. This patch early returns from `getDeps` if `deps` is
undefined.

This also changes `_transformDeps` to be initialised lazily once the
first 'dep' event happens, so that we're not unnecessarily concating
when there are no additional deps.
