### PR TITLE
Also emit 'file' event for files with syntax errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -417,7 +417,8 @@ Deps.prototype.walk = function (id, parent, cb) {
                 .on('error', cb)
                 .pipe(concat(function (body) {
                     var src = body.toString('utf8');
-                    var deps = getDeps(file, src);
+                    try { var deps = getDeps(file, src); }
+                    catch (err) { cb(err); }
                     if (deps) {
                         cb(null, {
                             source: src,
@@ -434,7 +435,6 @@ Deps.prototype.walk = function (id, parent, cb) {
 
     function getDeps (file, src) {
         var deps = rec.noparse ? [] : self.parseDeps(file, src);
-        if (!deps) return;
         // dependencies emitted by transforms
         if (self._transformDeps[file]) deps = deps.concat(self._transformDeps[file]);
         return deps;
@@ -504,10 +504,9 @@ Deps.prototype.parseDeps = function (file, src, cb) {
     try { var deps = detective(src) }
     catch (ex) {
         var message = ex && ex.message ? ex.message : ex;
-        this.emit('error', new Error(
+        throw new Error(
             'Parsing file ' + file + ': ' + message
-        ));
-        return;
+        );
     }
     return deps;
 };

--- a/test/syntax.js
+++ b/test/syntax.js
@@ -6,14 +6,18 @@ var through = require('through2');
 var path = require('path');
 
 test('syntax error', function (t) {
-    t.plan(1);
+    t.plan(2);
+    var input = path.join(__dirname, '/files/syntax_error.js');
     // ensure transformDeps functionality does not break when parse errors happen
     // see https://github.com/browserify/module-deps/commit/9fe46d5#commitcomment-28273437
     var p = mdeps({
         transform: function () { return through(); }
     });
+    p.on('file', function (file) {
+        t.equal(file, input, 'should emit a file event even if there was an error');
+    });
     p.on('error', function (err) {
         t.ok(err);
     });
-    p.end(path.join(__dirname, '/files/syntax_error.js'));
+    p.end(input);
 });


### PR DESCRIPTION
Previously, `parseDeps` emitted an error event when there was a syntax
error, and then returned undefined. Inside `persistentCacheFallback()`,
then, the callback would not be called. This used to be OK but the
persistent cache changes in v6 changed the callback, so now _it_ is
responsible for 'file' and 'error' events.

This patch changes `parseDeps` to throw instead of emit an error. This
bubbles up to `persistentCacheFallback()` where it is caught and passed
to the callback. Then that callback will first emit a 'file' event for
the file and only then emit the 'error' event.

This makes watchify aware of the file, so it will watch it and rebuild
when it changes. Fixes #144 (really this time!)