### PR TITLE
Adding basedir to fix node resolver

### DIFF
--- a/index.js
+++ b/index.js
@@ -464,6 +464,7 @@ Deps.prototype.walk = function (id, parent, cb) {
                 var current = {
                     id: file,
                     filename: file,
+                    basedir: path.dirname(file),
                     paths: self.paths,
                     package: pkg,
                     inNodeModules: parent.inNodeModules || !isTopLevel

--- a/test/files/resolve/bar/bar.js
+++ b/test/files/resolve/bar/bar.js
@@ -1,0 +1,5 @@
+var bar2 = require('./bar2');
+
+module.exports = function () {
+    return 'bar';
+};

--- a/test/files/resolve/bar/bar2.js
+++ b/test/files/resolve/bar/bar2.js
@@ -1,0 +1,3 @@
+module.exports = function () {
+    return 'bar2';
+};

--- a/test/files/resolve/foo/baz/baz.js
+++ b/test/files/resolve/foo/baz/baz.js
@@ -1,0 +1,3 @@
+module.exports = function () {
+    return 'baz';
+};

--- a/test/files/resolve/foo/foo.js
+++ b/test/files/resolve/foo/foo.js
@@ -1,0 +1,6 @@
+var bar = require('../bar/bar.js');
+var baz = require('./baz/baz.js');
+
+module.exports = function () {
+    return 'foo';
+};

--- a/test/resolve.js
+++ b/test/resolve.js
@@ -60,6 +60,9 @@ test('browser resolve - missing', function (t) {
 
     d.end({id: 'missing', file: missing, entry: true});
 
+    d.on('end', function () {
+        t.fail('errored');
+    });
     d.on('error', function (err) {
         t.match(
             String(err),
@@ -74,6 +77,9 @@ test('node resolve - missing', function (t) {
 
     d.end({id: 'missing', file: missing, entry: true});
 
+    d.on('end', function () {
+        t.fail('errored');
+    });
     d.on('error', function (err) {
         t.match(
             String(err),
@@ -93,8 +99,7 @@ test('browser resolve', function (t) {
     d.on('end', function () {
         t.same(rows, expectedRows);
     });
-
-    d.on('error', function (err) {
+    d.on('error', function () {
         t.fail('errored');
     });
 });
@@ -110,8 +115,7 @@ test('node resolve', function (t) {
     d.on('end', function () {
         t.same(rows, expectedRows);
     });
-
-    d.on('error', function (err) {
+    d.on('error', function () {
         t.fail('errored');
     });
 });

--- a/test/resolve.js
+++ b/test/resolve.js
@@ -1,0 +1,117 @@
+var fs = require('fs');
+var path = require('path');
+
+var mdeps = require('../');
+var test = require('tap').test;
+var nodeResolve = require('resolve');
+var browserResolve = require('browser-resolve');
+
+var missing = path.join(__dirname, '/missing');
+
+var files = {
+    foo: path.join(__dirname, '/files/resolve/foo/foo.js'),
+    bar: path.join(__dirname, '/files/resolve/bar/bar.js'),
+    bar2: path.join(__dirname, '/files/resolve/bar/bar2.js'),
+    baz: path.join(__dirname, '/files/resolve/foo/baz/baz.js')
+};
+
+var sources = Object.keys(files)
+    .reduce(function (acc, file) {
+        acc[file] = fs.readFileSync(files[file], 'utf8');
+        return acc;
+    }, {});
+
+var expectedRows = [
+    {
+        "deps": {},
+        "file": files.baz,
+        "id": files.baz,
+        "source": sources.baz
+    },
+    {
+        "deps": {},
+        "file": files.bar2,
+        "id": files.bar2,
+        "source": sources.bar2
+    },
+    {
+        "deps": {
+            "./bar2": files.bar2
+        },
+        "file": files.bar,
+        "id": files.bar,
+        "source": sources.bar
+    },
+    {
+        "deps": {
+            "../bar/bar.js": files.bar,
+            "./baz/baz.js": files.baz
+        },
+        "entry": true,
+        "file": files.foo,
+        "id": "foo",
+        "source": sources.foo
+    }
+];
+
+test('browser resolve - missing', function (t) {
+    t.plan(1);
+    var d = mdeps({resolve: browserResolve});
+
+    d.end({id: 'missing', file: missing, entry: true});
+
+    d.on('error', function (err) {
+        t.match(
+            String(err),
+            /Cannot find module .*/
+        );
+    });
+});
+
+test('node resolve - missing', function (t) {
+    t.plan(1);
+    var d = mdeps({resolve: nodeResolve});
+
+    d.end({id: 'missing', file: missing, entry: true});
+
+    d.on('error', function (err) {
+        t.match(
+            String(err),
+            /Cannot find module .*/
+        );
+    });
+});
+
+test('browser resolve', function (t) {
+    t.plan(1);
+    var d = mdeps({resolve: browserResolve});
+
+    d.end({id: 'foo', file: files.foo, entry: true});
+
+    var rows = [];
+    d.on('data', function (row) {rows.push(row)});
+    d.on('end', function () {
+        t.same(rows, expectedRows);
+    });
+
+    d.on('error', function (err) {
+        t.fail('errored');
+    });
+});
+
+test('node resolve', function (t) {
+    t.plan(1);
+    var d = mdeps({resolve: nodeResolve});
+
+    d.end({id: 'foo', file: files.foo, entry: true});
+
+    var rows = [];
+    d.on('data', function (row) {rows.push(row)});
+    d.on('end', function () {
+        t.same(rows, expectedRows);
+    });
+
+    d.on('error', function (err) {
+        t.fail('errored');
+    });
+});


### PR DESCRIPTION
in case you use node-resolve instead of the default browser-resolve the visitor fails as it can't find the required relative file from the currently visited, as the basedir is not set.
