### PR TITLE
fix dependency vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "JSONStream": "^1.0.3",
     "browser-resolve": "^1.7.0",
-    "cached-path-relative": "^1.0.0",
+    "cached-path-relative": "^1.0.2",
     "concat-stream": "~1.6.0",
     "defined": "^1.0.0",
     "detective": "^5.0.2",


### PR DESCRIPTION
Fix [https://www.npmjs.com/package/cached-path-relative](https://github.com/ashaffer/cached-path-relative) dependency package vulnerability described at https://nvd.nist.gov/vuln/detail/CVE-2018-16472 to avoid security alert.